### PR TITLE
Hiroaki222/issue51

### DIFF
--- a/messages/ja.json
+++ b/messages/ja.json
@@ -392,7 +392,8 @@
       "sad": "悲しい気持ちになった",
       "amused": "楽しませてくれた",
       "overall-aesthetic": "総合的な美的評価"
-    }
+    },
+    "expand-button": "拡大する"
   },
   "finish-confirmation-dialog": {
     "title": "アノテーションを終了しますか？",

--- a/src/app/annotation/page.tsx
+++ b/src/app/annotation/page.tsx
@@ -148,7 +148,7 @@ function AnnotationContent() {
             />
             {isExpanded && !isMobile && (
               <div
-                className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm pointer-events-auto"
+                className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm pointer-events-auto p-8"
                 onClick={() => setIsExpanded(false)}
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') {
@@ -157,7 +157,7 @@ function AnnotationContent() {
                 }}
                 tabIndex={-1}
               >
-                <div className="relative w-[90vw] h-[90vh] pointer-events-none">
+                <div className="relative w-full h-full max-w-[85vw] max-h-[85vh] pointer-events-none">
                   <button
                     onClick={() => setIsExpanded(false)}
                     className="absolute top-4 right-4 z-10 bg-black/50 hover:bg-black/70 text-white rounded-full p-2 transition-colors pointer-events-auto"
@@ -169,7 +169,8 @@ function AnnotationContent() {
                     <AnnotationTargetViewer
                       url={url}
                       setIsExpanded={setIsExpanded}
-                      isMobile={false}
+                      isMobile={true}
+                      isFullScreen={true}
                     />
                   ) : (
                     <div className="flex items-center justify-center w-full h-full pointer-events-none">

--- a/src/app/annotation/page.tsx
+++ b/src/app/annotation/page.tsx
@@ -63,7 +63,8 @@ function AnnotationContent() {
       setIsExpanded(false);
       setIsMobile(true)
     }
-    dataType.current = annotationTargets.data.tag;
+    //dataType.current = annotationTargets.data.tag;
+    dataType.current = 'video';
   }, [annotationTargets]);
 
   useEffect(() => {

--- a/src/app/annotation/page.tsx
+++ b/src/app/annotation/page.tsx
@@ -24,6 +24,8 @@ function AnnotationContent() {
   const [startTime, setStartTime] = useState<number>(performance.now() / 1000);
   const prevStepRef = useRef<number>(1);
 
+  const dataType = useRef<string>('');
+
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -61,6 +63,7 @@ function AnnotationContent() {
       setIsExpanded(false);
       setIsMobile(true)
     }
+    dataType.current = annotationTargets.data.tag;
   }, [annotationTargets]);
 
   useEffect(() => {
@@ -129,6 +132,7 @@ function AnnotationContent() {
                 isExpanded={isExpanded}
                 setIsExpanded={isMobile ? () => { } : setIsExpanded}
                 isMobile={isMobile}
+                dataType={dataType.current}
               />
               <AnnotationInput
                 annotationResult={annotationResult}
@@ -170,6 +174,7 @@ function AnnotationContent() {
                       url={url}
                       setIsExpanded={setIsExpanded}
                       isMobile={true}
+                      dataType={dataType.current}
                       isFullScreen={true}
                     />
                   ) : (

--- a/src/app/annotation/page.tsx
+++ b/src/app/annotation/page.tsx
@@ -63,8 +63,7 @@ function AnnotationContent() {
       setIsExpanded(false);
       setIsMobile(true)
     }
-    //dataType.current = annotationTargets.data.tag;
-    dataType.current = 'video';
+    dataType.current = annotationTargets.data.tag;
   }, [annotationTargets]);
 
   useEffect(() => {
@@ -154,7 +153,7 @@ function AnnotationContent() {
             {isExpanded && !isMobile && (
               <div
                 className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm pointer-events-auto p-8"
-                onClick={() => setIsExpanded(false)}
+                onClick={() => { if (dataType.current !== 'video') setIsExpanded(false); }}
                 onKeyDown={(e) => {
                   if (e.key === 'Escape') {
                     setIsExpanded(false);
@@ -162,7 +161,9 @@ function AnnotationContent() {
                 }}
                 tabIndex={-1}
               >
-                <div className="relative w-full h-full max-w-[85vw] max-h-[85vh] pointer-events-none">
+                <div className={
+                  `relative w-full h-full max-w-[85vw] max-h-[85vh] ${dataType.current === 'video' ? 'pointer-events-auto' : 'pointer-events-none'}`
+                }>
                   <button
                     onClick={() => setIsExpanded(false)}
                     className="absolute top-4 right-4 z-10 bg-black/50 hover:bg-black/70 text-white rounded-full p-2 transition-colors pointer-events-auto"

--- a/src/app/annotation/page.tsx
+++ b/src/app/annotation/page.tsx
@@ -9,7 +9,7 @@ import { fetchAnnotation, saveAnnotation } from "@/utils/annotation";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useState, Suspense, useRef } from "react"
 import AnnotationControl from "@/components/annotation-control";
-import Image from "next/image";
+import AnnotationTargetViewer from "@/components/annotation-target-viewer";
 import { LoaderCircle, X } from "lucide-react";
 import { fetchUser } from "@/utils/supabase/actions";
 
@@ -166,14 +166,10 @@ function AnnotationContent() {
                     <X size={24} />
                   </button>
                   {url ? (
-                    <Image
-                      src={url}
-                      alt="Annotation Target Expanded"
-                      fill
-                      sizes="100vw"
-                      className="object-contain pointer-events-auto"
-                      onClick={(e) => e.stopPropagation()}
-                      priority={true}
+                    <AnnotationTargetViewer
+                      url={url}
+                      setIsExpanded={setIsExpanded}
+                      isMobile={false}
                     />
                   ) : (
                     <div className="flex items-center justify-center w-full h-full pointer-events-none">

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -1,10 +1,9 @@
 import Image from "next/image";
-import { Card } from "./ui/card";
 import { Expand } from "lucide-react";
 
 export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; isFullScreen?: boolean }) {
   return (
-    <Card className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
+    <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
       <div className={`relative ${isFullScreen ? 'w-full h-full' : 'w-full'} flex items-center justify-center`}>
         <Image
           src={url}
@@ -20,6 +19,6 @@ export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, i
           <Expand className="text-white hover:text-white transition-colors drop-shadow-md bg-black/20 rounded p-1" />
         </button>
       ) : null}
-    </Card>
+    </div>
   )
 }

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
-import { Expand } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { Button } from "./ui/button";
+import { useTranslations } from "next-intl";
 
 export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, dataType, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string; isFullScreen?: boolean }) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const t = useTranslations('annotation');
 
   useEffect(() => {
     if (dataType === 'video' && videoRef.current) {
@@ -31,7 +33,7 @@ export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, d
 
   if (dataType === 'video') isMobile = true;
   return (
-    <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
+    <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center flex-col relative'}`}>
       <div className={`relative ${isFullScreen ? 'w-full h-full' : 'w-full'} flex items-center justify-center`}>
         {
           dataType === 'Img' ? (
@@ -61,9 +63,9 @@ export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, d
         }
       </div>
       {!isMobile ? (
-        <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2 z-10">
-          <Expand className="text-white hover:text-white transition-colors drop-shadow-md bg-black/20 rounded p-1" />
-        </button>
+        <Button className="m-5 w-1/4 font-bold" onClick={() => setIsExpanded(true)}>
+          <a>{t('expand-button')}</a>
+        </Button>
       ) : null}
     </div>
   )

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -2,18 +2,33 @@ import Image from "next/image";
 import { Expand } from "lucide-react";
 
 export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, dataType, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string; isFullScreen?: boolean }) {
-  console.log(dataType)
+  const videoUrl = 'https://bvy3dtfuknsslhnc.public.blob.vercel-storage.com/sample.mp4';
+  if (dataType === 'video') isMobile = true;
   return (
     <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
       <div className={`relative ${isFullScreen ? 'w-full h-full' : 'w-full'} flex items-center justify-center`}>
-        <Image
-          src={url}
-          alt="Annotation Target"
-          width={1920}
-          height={1080}
-          className={`${isFullScreen ? 'max-w-full max-h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
-          priority={true}
-        />
+        {
+          dataType === 'Img' ? (
+            <Image
+              src={url}
+              alt="Annotation Target"
+              width={1920}
+              height={1080}
+              className={`${isFullScreen ? 'max-w-full max-h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
+              priority={true}
+            />
+          ) : (
+            dataType === 'video' ? (
+              <video
+                src={videoUrl}
+                className={`${isFullScreen ? 'max-w-full max-h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
+                controls
+                autoPlay
+                loop
+              />
+            ) : null
+          )
+        }
       </div>
       {!isMobile ? (
         <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2 z-10">

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -1,7 +1,8 @@
 import Image from "next/image";
 import { Expand } from "lucide-react";
 
-export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; isFullScreen?: boolean }) {
+export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, dataType, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string; isFullScreen?: boolean }) {
+  console.log(dataType)
   return (
     <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
       <div className={`relative ${isFullScreen ? 'w-full h-full' : 'w-full'} flex items-center justify-center`}>

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -1,0 +1,16 @@
+import Image from "next/image";
+import { Card } from "./ui/card";
+import { Expand } from "lucide-react";
+
+export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean }) {
+  return (
+    <Card className="p-0 overflow-hidden w-full flex items-center justify-center relative">
+      <Image src={url} alt="Annotation Target" width={1920} height={1080} className="w-full" priority={true} />
+      {!isMobile ? (
+        <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2">
+          <Expand className="text-white hover:text-white transition-colors drop-shadow-md bg-black/20 rounded p-1" />
+        </button>
+      ) : null}
+    </Card>
+  )
+}

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -2,12 +2,21 @@ import Image from "next/image";
 import { Card } from "./ui/card";
 import { Expand } from "lucide-react";
 
-export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean }) {
+export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; isFullScreen?: boolean }) {
   return (
-    <Card className="p-0 overflow-hidden w-full flex items-center justify-center relative">
-      <Image src={url} alt="Annotation Target" width={1920} height={1080} className="w-full" priority={true} />
+    <Card className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
+      <div className={`relative ${isFullScreen ? 'w-full h-full' : 'w-full'} flex items-center justify-center`}>
+        <Image
+          src={url}
+          alt="Annotation Target"
+          width={1920}
+          height={1080}
+          className={`${isFullScreen ? 'max-w-full max-h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
+          priority={true}
+        />
+      </div>
       {!isMobile ? (
-        <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2">
+        <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2 z-10">
           <Expand className="text-white hover:text-white transition-colors drop-shadow-md bg-black/20 rounded p-1" />
         </button>
       ) : null}

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -3,7 +3,6 @@ import { Expand } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, dataType, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string; isFullScreen?: boolean }) {
-  const videoUrl = 'https://bvy3dtfuknsslhnc.public.blob.vercel-storage.com/__GEoXDwIjI_0089636_0091436.mp4';
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
@@ -48,7 +47,7 @@ export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, d
             dataType === 'video' ? (
               <video
                 ref={videoRef}
-                src={videoUrl}
+                src={url}
                 className={`${isFullScreen ? 'w-full h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
                 controls
                 autoPlay

--- a/src/components/annotation-target-viewer.tsx
+++ b/src/components/annotation-target-viewer.tsx
@@ -1,8 +1,35 @@
 import Image from "next/image";
 import { Expand } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, dataType, isFullScreen = false }: { url: string; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string; isFullScreen?: boolean }) {
-  const videoUrl = 'https://bvy3dtfuknsslhnc.public.blob.vercel-storage.com/sample.mp4';
+  const videoUrl = 'https://bvy3dtfuknsslhnc.public.blob.vercel-storage.com/__GEoXDwIjI_0089636_0091436.mp4';
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (dataType === 'video' && videoRef.current) {
+      const video = videoRef.current;
+
+      const playVideo = async () => {
+        try {
+          await video.play();
+        } catch (error) {
+          console.warn('Auto-play failed:', error);
+        }
+      };
+
+      if (video.readyState >= 3) {
+        playVideo();
+      } else {
+        video.addEventListener('loadeddata', playVideo);
+      }
+
+      return () => {
+        video.removeEventListener('loadeddata', playVideo);
+      };
+    }
+  }, [dataType]);
+
   if (dataType === 'video') isMobile = true;
   return (
     <div className={`${isFullScreen ? 'p-0 overflow-hidden w-full h-full flex items-center justify-center relative border-0 bg-transparent' : 'p-0 overflow-hidden w-full flex items-center justify-center relative'}`}>
@@ -20,11 +47,15 @@ export default function AnnotationTargetViewer({ url, setIsExpanded, isMobile, d
           ) : (
             dataType === 'video' ? (
               <video
+                ref={videoRef}
                 src={videoUrl}
-                className={`${isFullScreen ? 'max-w-full max-h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
+                className={`${isFullScreen ? 'w-full h-full object-contain' : 'w-full h-auto max-h-[70vh] object-contain'}`}
                 controls
                 autoPlay
                 loop
+                muted
+                playsInline
+                preload="metadata"
               />
             ) : null
           )

--- a/src/components/annotation-target.tsx
+++ b/src/components/annotation-target.tsx
@@ -2,12 +2,12 @@ import { Card } from "./ui/card";
 import { LoaderCircle } from "lucide-react";
 import AnnotationTargetViewer from "./annotation-target-viewer";
 
-export default function AnnotationTarget({ url, setIsExpanded, isMobile }: { url: string; isExpanded: boolean; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean }) {
+export default function AnnotationTarget({ url, setIsExpanded, isMobile, dataType }: { url: string; isExpanded: boolean; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean; dataType: string }) {
   return (
     <>
       <div className="w-full md:w-1/3 flex items-center justify-center">
         {url ? (
-          <AnnotationTargetViewer url={url} setIsExpanded={setIsExpanded} isMobile={isMobile} />
+          <AnnotationTargetViewer url={url} setIsExpanded={setIsExpanded} isMobile={isMobile} dataType={dataType} />
         ) : (
           <Card className="p-0 overflow-hidden flex items-center justify-center relative w-full]">
             <LoaderCircle className="animate-spin" />

--- a/src/components/annotation-target.tsx
+++ b/src/components/annotation-target.tsx
@@ -1,20 +1,13 @@
-import Image from "next/image";
 import { Card } from "./ui/card";
-import { Expand, LoaderCircle } from "lucide-react";
+import { LoaderCircle } from "lucide-react";
+import AnnotationTargetViewer from "./annotation-target-viewer";
 
 export default function AnnotationTarget({ url, setIsExpanded, isMobile }: { url: string; isExpanded: boolean; setIsExpanded: (isExpanded: boolean) => void; isMobile: boolean }) {
   return (
     <>
       <div className="w-full md:w-1/3 flex items-center justify-center">
         {url ? (
-          <Card className="p-0 overflow-hidden w-full flex items-center justify-center relative">
-            <Image src={url} alt="Annotation Target" width={1920} height={1080} className="w-full" priority={true} />
-            {!isMobile ? (
-              <button onClick={() => setIsExpanded(true)} className="absolute top-2 right-2">
-                <Expand className="text-white hover:text-white transition-colors drop-shadow-md bg-black/20 rounded p-1" />
-              </button>
-            ) : null}
-          </Card>
+          <AnnotationTargetViewer url={url} setIsExpanded={setIsExpanded} isMobile={isMobile} />
         ) : (
           <Card className="p-0 overflow-hidden flex items-center justify-center relative w-full]">
             <LoaderCircle className="animate-spin" />


### PR DESCRIPTION
# 1. アノテーションページ
## 1.1. 動画ビューの実装

## 1.1.1 ステップ遷移時の画面
<img width="3588" height="2552" alt="Microsoft Edge 2025-08-14 00 09 36" src="https://github.com/user-attachments/assets/24fdea81-d77f-4b39-bbbf-8d3cecd09122" />

## 1.1.2 アノテーション画面
<img width="3588" height="2552" alt="image" src="https://github.com/user-attachments/assets/0969f5a1-f16c-47c4-ba3b-0d00eb1f520e" />

## 1.2. 拡大ボタンの変更
アノテーション対象画像のサイズにより拡大ボタンのレンダリング処理が面倒だったので切り離しました．
アノテーション対象画像の上にボタンを表示するのはそもそもノイズなので良くなかった気もします．
<img width="3588" height="2552" alt="image" src="https://github.com/user-attachments/assets/75f20f6e-77c3-44f7-9a95-72ca6be095f2" />



